### PR TITLE
Correction de l'enregistrement des notes d'une recette.

### DIFF
--- a/joliebulle/export.py
+++ b/joliebulle/export.py
@@ -153,7 +153,7 @@ class Export (QtCore.QObject):
 
         try :
             notes = ET.SubElement(recipeTag, 'NOTES') 
-            notes.text = self.recipe.recipeNotes
+            notes.text = recipe.recipeNotes
         except :
             pass       
 


### PR DESCRIPTION
Actuellement, les notes qui accompagne une recette ne sont pas enregistrées voire, dans le cadre d'une recette existante, peuvent être supprimée.
