### PR TITLE
Corrige les calculs de volume en mode brassage

### DIFF
--- a/joliebulle/model/recipe.py
+++ b/joliebulle/model/recipe.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3.1
 #­*­coding: utf­8 -­*­
 
-
-
 #JolieBulle 2.6
 #Copyright (C) 2010-2012 Pierre Tavares
 
@@ -19,6 +17,7 @@
 #You should have received a copy of the GNU General Public License
 #along with this program; if not, write to the Free Software
 #Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
 import logging
 import model.constants
 from model.fermentable import *
@@ -113,10 +112,7 @@ class Recipe:
         return recipe
 
     def compute_fermentablesWeight(self):
-        grainWeight = 0
-        for f in self.listeFermentables:
-            grainWeight += f.amount
-        return grainWeight
+        return sum([f.amount for f in self.listeFermentables])
 
     def compute_equivSugar(self):
         self.equivSugar = 0.0
@@ -236,7 +232,4 @@ class Recipe:
         return hash_proportion
 
     def compute_grainWeight(self):
-        grainWeight = 0
-        for f in self.listeFermentables:
-            grainWeight += f.amount
-        return grainWeight
+        return sum([f.amount for f in self.listeFermentables if f.type != model.constants.FERMENTABLE_TYPE_SUGAR])


### PR DESCRIPTION
Corrige l'erreur reportée en #7
La classe Recipe comportait les deux méthodes suivantes pour obtenir la masse des éléments fermentables :
- compute_fermentablesWeight()
- compute_grainWeight()

Ces méthodes retournaient toutes les deux la masse totale. La modification apportée modifie le comportement de compute_grainWeight() qui retourne désormais uniquement la masse de fermentables à l'exclusion du sucre.
À noter que compute_fermentablesWeight() ne semble pas être utilisée.

Par ailleurs, au delà du sucre, le comportement de JolieBulle n'est pas adapté aux brassages en extrait puisque l'on passe forcément par une phase d'empatage non présente dans ce type de brassage.
Dans le cas, d'un brassage mixte (grain/extrait) qu'elle est la règle à adopter ? L'extrait est il à considérer comme du sucre ? Je dirais volontiers que oui mais je ne suis pas un adepte de ces techniques. Si c'est le cas je dois corriger la modification actuelle.
