### PR TITLE
Fix 127

### DIFF
--- a/joliebulle/helper/recipeimporter/importBeerXML.py
+++ b/joliebulle/helper/recipeimporter/importBeerXML.py
@@ -183,7 +183,10 @@ def importBeerXMLHop(data):
             else :
                 logger.warn ("Unkown hop use '%s', assuming 'Boil' by default", child.text)
                 hop.use = model.constants.HOP_USE_BOIL
-    
+
+    if hop.use == 'Dry Hop':
+        hop.time /= 24*60
+
     return hop
 
 
@@ -205,7 +208,7 @@ def importBeerXMLMash(data):
     mashStep = data.findall('.//MASH_STEP')
     for element in mashStep:
         mash.listeSteps.append(importBeerXMLMashStep(element))
-    
+
     return mash
 
 
@@ -230,7 +233,7 @@ def importBeerXMLMashStep(data):
             mashStep.temp = "%.1f" % float(child.text)
         if 'INFUSE_AMOUNT' == child.tag:
             mashStep.infuseAmount = float(child.text)
-    
+
     return mashStep
 
 

--- a/joliebulle/static/beercalc/jb2bb.js
+++ b/joliebulle/static/beercalc/jb2bb.js
@@ -29,8 +29,12 @@ var jb2bb = (function () {
 
 			string += "[b]Houblons \n";
 			string += "------------------------ [/b] \n";
-			recipe.hops.forEach(function (hop) {
-				string += hop.amount + " g " + hop.name + " (α" + hop.alpha + "%, " + hop.formView + ") @ " + hop.time + " min (" + hop.useView + ")" + "\n";
+		        recipe.hops.forEach(function (hop) {
+                            var unit_time = "min";
+                            if (hop.use === 'Dry Hop') {
+                                unit_time = "jours";
+                            }
+			    string += hop.amount + " g " + hop.name + " (α" + hop.alpha + "%, " + hop.formView + ") @ " + hop.time + " " + unit_time + " (" + hop.useView + ")" + "\n";
 			});
 			string += "\n";
 

--- a/joliebulle/static/beercalc/jb2xml.js
+++ b/joliebulle/static/beercalc/jb2xml.js
@@ -47,6 +47,7 @@ var jb2xml = (function () {
                 }
                 if (hop.use === 'Dry Hop') {
                     string += "<TIME>" + hop.time*24*60 + "</TIME>";
+                    string += "<DISPLAY_TIME>" + hop.time + " days</DISPLAY_TIME>";
                 } else {
                     string += "<TIME>" + hop.time + "</TIME>";
                 }

--- a/joliebulle/static/beercalc/jb2xml.js
+++ b/joliebulle/static/beercalc/jb2xml.js
@@ -45,7 +45,11 @@ var jb2xml = (function () {
                 } else if (hop.form === 2 || hop.form === 'Plug') {
                     string += "<FORM>Plug</FORM>";
                 }
-                string += "<TIME>" + hop.time + "</TIME>";
+                if (hop.use === 'Dry Hop') {
+                    string += "<TIME>" + hop.time*24*60 + "</TIME>";
+                } else {
+                    string += "<TIME>" + hop.time + "</TIME>";
+                }
                 string += "<ALPHA>" + hop.alpha + "</ALPHA>";
                 string += "<USE>" + hop.use + "</USE>";
                 string += "</HOP>";

--- a/joliebulle/static/html/lib.html
+++ b/joliebulle/static/html/lib.html
@@ -204,14 +204,14 @@
 
                   <tbody>
                     <tr ng-repeat="hop in currentRecipe.hops" ng-click="editHop($index)">
-                      <td>{{hop.name}} 
+                      <td>{{hop.name}}
                           <span class="bulle" ng-hide="editMode"><ul>
                             <li>Alpha : {{hop.alpha | number : 1}} %</li>
                             <li>Contribution : {{hop.ibuPart | number : 1}} IBU</li>
                           </ul></span>
                           <span class="clickEdit" ng-show="editMode">Cliquer pour éditer</span></td>
                       <td>{{hop.amount | number : 0}} g <span ng-show="editMode" class="amountRatio">   ({{hop.ibuPart | number : 1}} IBU)</span></td>
-                      <td>{{hop.useView}} - {{hop.time}} min</td>
+                      <td>{{hop.useView}} - {{hop.time}} {{hop.useView=='Dry Hop' ? 'jours' : 'min'}}</td>
                       <td ng-show="editMode"><button class="btn-link btn-xs table-button removeIngredient" type="button" ng-show="editMode" ng-click="removeHop($index)"><i class="fa fa-times"></i></button></td>
                     </tr>
                   </tbody>
@@ -372,7 +372,7 @@
 
 
           <div>
-            <label >Durée (min)</label>
+            <label>Durée ({{currentHop.useView=='Dry Hop' ? 'jours' : 'min'}})</label>
             <input type="number" ng-model="currentHop.time" ng-change="calcProfile(currentRecipe)">
           </div>
           <div>


### PR DESCRIPTION
Another proposal for #127 based on previous feedback.

The variable hop.time is kept to reflect what is on UI. It's only when we export/import that we convert into minutes or days.

The problem is that with python xml exporter seems to be dead code. Therefore, I cannot patch it since I cannot test it unless writing specific tests. 

I would suggest to go for removal of such code if you are okay with that. And if this exporter is used somewhere, can you please suggest a way to test it ?